### PR TITLE
Use $olddir variable

### DIFF
--- a/makesymlinks.sh
+++ b/makesymlinks.sh
@@ -6,7 +6,7 @@
 
 ########## Variables
 
-dir=`pwd`
+dir=$(pwd)
 olddir=~/dotfiles_old             # old dotfiles backup directory
 files="bashrc vimrc vim zshrc oh-my-zsh private scrotwm.conf Xresources"    # list of files/folders to symlink in homedir
 


### PR DESCRIPTION
I loved your blog post on creating dotfiles.  You explained it very well.  I just saw this one part where you were hard coding the backup directory rather than using the variable.  If someone were to rename the path, it would break on the hard coded line.  I also thought it would be nice to be able to clone it anywhere and have it link to the location of the cloned dotfiles.
