### PR TITLE
suppress error messages for qfind

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -55,7 +55,7 @@ alias get='git '
 
 # qfind - used to quickly find files that contain a string in a directory
 qfind () {
-    find . -exec grep -l $1 {} \;
+    find . -exec grep -l -s $1 {} \;
     return 0
 }
 


### PR DESCRIPTION
I really like qfind, but found the grep messages that foo is a directory to just take up a lot of space, especially when traversing git folders. Added the -s to suppress these messages. 
![2013-08-21-205559_1920x1080_scrot](https://f.cloud.github.com/assets/1045990/1005764/e608744c-0ac5-11e3-8974-f070161dfc85.png)
